### PR TITLE
drop oracle jdk 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 jdk:
-  - oraclejdk8
   - openjdk8
   
 os:


### PR DESCRIPTION
Oracle JDK 8 niet langer beschikbaar op travis-CI